### PR TITLE
Fix bug where parsing a line wouldn't make points

### DIFF
--- a/backend/main_parser.py
+++ b/backend/main_parser.py
@@ -53,6 +53,7 @@ def parse_line(args, obj):
         if obj.get(p) is None:
             point = primitives.Point(p)
             point_list.append(point)
+            obj[p] = point
         else:
             point_list.append(obj[p])
 


### PR DESCRIPTION
- When parsing a line, if the points on the line did not exist yet, the
point objects would not be created. This was a simple oversight, and was
a quick one line change
- Closes #12