### PR TITLE
Remove `step` from output, other step fixes

### DIFF
--- a/backend/main_parser.py
+++ b/backend/main_parser.py
@@ -25,8 +25,8 @@ def parse(text):
     # Dictionary to hold all of the objects that we create.
     # The mapping is between names of the object and the object itself
     object_dict = {}
-    animations = None
-    curr_step = None
+    animations = []
+    curr_step = []
 
     pattern = r'[^\\]?`([\s\S]*?)`'
 
@@ -37,15 +37,12 @@ def parse(text):
             element_type = data[0]
             arguments = data[1:]
             if element_type == 'step':
-                if(animations is None):
-                    animations = []
-                    curr_step = []
                 if(len(curr_step) > 0):
                     animations.append(curr_step)
                     curr_step = []
             else:
                 obj = parsers[element_type](arguments, object_dict)
-                if(animations is not None and obj is not None):
+                if obj is not None:
                     curr_step.append(obj.name)
 
     return create_output(object_dict, text, animations)
@@ -70,6 +67,7 @@ def create_output(dict, text, animations):
 def format_text(text):
     newtext = []
     for i in text:
+        i = i.replace('`step`', '')
         if not i.startswith('`loc'):
             newtext.append(i)
     newtext = newtext[:-1]

--- a/backend/main_parser.py
+++ b/backend/main_parser.py
@@ -78,7 +78,6 @@ def format_text(text):
 
 
 def parse_line(args, obj):
-    created = False
     name = ''.join(sorted([x for x in args]))
     point_list = []
 

--- a/frontend/postulate1.html
+++ b/frontend/postulate1.html
@@ -11,125 +11,174 @@
 		  window.onload = init
 
 		  geometry = {
-    "text": "Let <span id=text_line_AB style='background-color: #dddddd'>line AB</span> be the given finite straight line.\nIt is required to construct an equilateral triangle on the straight <span id=text_line_AB style='background-color: #dddddd'>line AB</span>.\nDescribe the <span id=text_circle_BCD style='background-color: #dddddd'>circle BCD</span> with <span id=text_center_A style='background-color: #dddddd'>center A</span> and radius <span id=text_line_AB style='background-color: #dddddd'>line AB</span>.\nAgain describe the <span id=text_circle_ACE style='background-color: #dddddd'>circle ACE</span> with <span id=text_center_B style='background-color: #dddddd'>center B</span> and radius <span id=text_line_BA style='background-color: #dddddd'>line BA</span>.\nJoin the straight lines <span id=text_line_CA style='background-color: #dddddd'>line CA</span> and <span id=text_line_CB style='background-color: #dddddd'>line CB</span> from the <span id=text_point_C style='background-color: #dddddd'>point C</span> at which the circles cut one another to the points <span id=text_point_A style='background-color: #dddddd'>point A</span> and <span id=text_point_B style='background-color: #dddddd'>point B</span>.\nNow, since the <span id=text_point_A style='background-color: #dddddd'>point A</span> is the center of the <span id=text_circle_CDB style='background-color: #dddddd'>circle CDB</span>, therefore <span id=text_line_AC style='background-color: #dddddd'>line AC</span> equals <span id=text_line_AB style='background-color: #dddddd'>line AB</span>.\nAgain, since the <span id=text_point_B style='background-color: #dddddd'>point B</span> is the center of the <span id=text_circle_CAE style='background-color: #dddddd'>circle CAE</span>, therefore <span id=text_line_BC style='background-color: #dddddd'>line BC</span> equals <span id=text_line_BA style='background-color: #dddddd'>line BA</span>.\nBut <span id=text_line_AC style='background-color: #dddddd'>line AC</span> was proved equal to <span id=text_line_AB style='background-color: #dddddd'>line AB</span>, therefore each of the straight lines <span id=text_line_AC style='background-color: #dddddd'>line AC</span> and <span id=text_line_BC style='background-color: #dddddd'>line BC</span> equals <span id=text_line_AB style='background-color: #dddddd'>line AB</span>.\nAnd things which equal the same thing also equal one another, therefore <span id=text_line_AC style='background-color: #dddddd'>line AC</span> also equals <span id=text_line_BC style='background-color: #dddddd'>line BC</span>.\nTherefore the three straight lines <span id=text_line_AC style='background-color: #dddddd'>line AC</span>, <span id=text_line_AB style='background-color: #dddddd'>line AB</span>, and <span id=text_line_BC style='background-color: #dddddd'>line BC</span> equal one another.\nTherefore the <span id=text_triangle_ABC style='background-color: #dddddd'>triangle ABC</span> is equilateral, and it has been constructed on the given finite straight <span id=text_line_AB style='background-color: #dddddd'>line AB</span>.\n",
+    "text": "Let <span id=text_line_AB style='background-color: #dddddd'>line AB</span> be the given finite straight line.\nIt is required to construct an equilateral triangle on the straight <span id=text_line_AB style='background-color: #dddddd'>line AB</span>. \nDescribe the <span id=text_circle_BCD style='background-color: #dddddd'>circle BCD</span> with <span id=text_center_A style='background-color: #dddddd'>center A</span> and radius <span id=text_line_AB style='background-color: #dddddd'>line AB</span>. \nAgain describe the <span id=text_circle_ACE style='background-color: #dddddd'>circle ACE</span> with <span id=text_center_B style='background-color: #dddddd'>center B</span> and radius <span id=text_line_BA style='background-color: #dddddd'>line BA</span>. \nJoin the straight lines <span id=text_line_CA style='background-color: #dddddd'>line CA</span> and <span id=text_line_CB style='background-color: #dddddd'>line CB</span> from the <span id=text_point_C style='background-color: #dddddd'>point C</span> at which the circles cut one another to the points <span id=text_point_A style='background-color: #dddddd'>point A</span> and <span id=text_point_B style='background-color: #dddddd'>point B</span>. \nNow, since the <span id=text_point_A style='background-color: #dddddd'>point A</span> is the center of the <span id=text_circle_CDB style='background-color: #dddddd'>circle CDB</span>, therefore <span id=text_line_AC style='background-color: #dddddd'>line AC</span> equals <span id=text_line_AB style='background-color: #dddddd'>line AB</span>.\nAgain, since the <span id=text_point_B style='background-color: #dddddd'>point B</span> is the center of the <span id=text_circle_CAE style='background-color: #dddddd'>circle CAE</span>, therefore <span id=text_line_BC style='background-color: #dddddd'>line BC</span> equals <span id=text_line_BA style='background-color: #dddddd'>line BA</span>.\nBut <span id=text_line_AC style='background-color: #dddddd'>line AC</span> was proved equal to <span id=text_line_AB style='background-color: #dddddd'>line AB</span>, therefore each of the straight lines <span id=text_line_AC style='background-color: #dddddd'>line AC</span> and <span id=text_line_BC style='background-color: #dddddd'>line BC</span> equals <span id=text_line_AB style='background-color: #dddddd'>line AB</span>.\nAnd things which equal the same thing also equal one another, therefore <span id=text_line_AC style='background-color: #dddddd'>line AC</span> also equals <span id=text_line_BC style='background-color: #dddddd'>line BC</span>.\nTherefore the three straight lines <span id=text_line_AC style='background-color: #dddddd'>line AC</span>, <span id=text_line_AB style='background-color: #dddddd'>line AB</span>, and <span id=text_line_BC style='background-color: #dddddd'>line BC</span> equal one another.\nTherefore the <span id=text_triangle_ABC style='background-color: #dddddd'>triangle ABC</span> is equilateral, and it has been constructed on the given finite straight <span id=text_line_AB style='background-color: #dddddd'>line AB</span>. \n",
     "geometry": [
         {
-            "type": "Point",
-            "id": "A",
-            "data": {
-                "x": -0.25,
-                "y": 0.0
+            "A": {
+                "type": "Point",
+                "id": "A",
+                "data": {
+                    "x": -0.25,
+                    "y": 0.0
+                }
             }
         },
         {
-            "type": "Point",
-            "id": "B",
-            "data": {
-                "x": 0.25,
-                "y": 0.0
+            "B": {
+                "type": "Point",
+                "id": "B",
+                "data": {
+                    "x": 0.25,
+                    "y": 0.0
+                }
             }
         },
         {
-            "type": "Line",
-            "id": "AB",
-            "data": {
-                "p1": "A",
-                "p2": "B"
+            "AB": {
+                "type": "Line",
+                "id": "AB",
+                "data": {
+                    "p1": "A",
+                    "p2": "B"
+                }
             }
         },
         {
-            "type": "Point",
-            "id": "C",
-            "data": {
-                "x": 0.0,
-                "y": 0.433
+            "C": {
+                "type": "Point",
+                "id": "C",
+                "data": {
+                    "x": 0.0,
+                    "y": 0.433
+                }
             }
         },
         {
-            "type": "Point",
-            "id": "D",
-            "data": {
-                "x": -0.75,
-                "y": 0.0
+            "D": {
+                "type": "Point",
+                "id": "D",
+                "data": {
+                    "x": -0.75,
+                    "y": 0.0
+                }
             }
         },
         {
-            "type": "Circle",
-            "id": "BCD",
-            "data": {
-                "p1": "B",
-                "p2": "C",
-                "p3": "D",
-                "center": "A"
+            "BCD": {
+                "type": "Circle",
+                "id": "BCD",
+                "data": {
+                    "p1": "B",
+                    "p2": "C",
+                    "p3": "D",
+                    "center": null
+                }
             }
         },
         {
-            "type": "Point",
-            "id": "E",
-            "data": {
-                "x": 0.75,
-                "y": 0.0
+            "E": {
+                "type": "Point",
+                "id": "E",
+                "data": {
+                    "x": 0.75,
+                    "y": 0.0
+                }
             }
         },
         {
-            "type": "Circle",
-            "id": "ACE",
-            "data": {
-                "p1": "A",
-                "p2": "C",
-                "p3": "E",
-                "center": "B"
+            "ACE": {
+                "type": "Circle",
+                "id": "ACE",
+                "data": {
+                    "p1": "A",
+                    "p2": "C",
+                    "p3": "E",
+                    "center": null
+                }
             }
         },
         {
-            "type": "Line",
-            "id": "BA",
-            "data": {
-                "p1": "B",
-                "p2": "A"
+            "BA": {
+                "type": "Line",
+                "id": "BA",
+                "data": {
+                    "p1": "B",
+                    "p2": "A"
+                }
             }
         },
         {
-            "type": "Line",
-            "id": "CA",
-            "data": {
-                "p1": "C",
-                "p2": "A"
+            "CA": {
+                "type": "Line",
+                "id": "CA",
+                "data": {
+                    "p1": "C",
+                    "p2": "A"
+                }
             }
         },
         {
-            "type": "Line",
-            "id": "CB",
-            "data": {
-                "p1": "C",
-                "p2": "B"
+            "CB": {
+                "type": "Line",
+                "id": "CB",
+                "data": {
+                    "p1": "C",
+                    "p2": "B"
+                }
             }
         },
         {
-            "type": "Line",
-            "id": "AC",
-            "data": {
-                "p1": "A",
-                "p2": "C"
+            "AC": {
+                "type": "Line",
+                "id": "AC",
+                "data": {
+                    "p1": "A",
+                    "p2": "C"
+                }
             }
         },
         {
-            "type": "Line",
-            "id": "BC",
-            "data": {
-                "p1": "B",
-                "p2": "C"
+            "BC": {
+                "type": "Line",
+                "id": "BC",
+                "data": {
+                    "p1": "B",
+                    "p2": "C"
+                }
             }
         },
         {
-            "type": "Triangle",
-            "id": "ABC",
-            "data": {
-                "p1": "A",
-                "p2": "B",
-                "p3": "C"
+            "ABC": {
+                "type": "Triangle",
+                "id": "ABC",
+                "data": {
+                    "p1": "A",
+                    "p2": "B",
+                    "p3": "C"
+                }
             }
         }
+    ],
+    "animations": [
+        [
+            "AB"
+        ],
+        [
+            "BCD"
+        ],
+        [
+            "ACE",
+            "BA"
+        ],
+        [
+            "CA",
+            "CB"
+        ],
+        [
+            "AC",
+            "BC",
+            "ABC"
+        ]
     ]
 }
 
@@ -137,8 +186,7 @@
 	</head>
 	<body>
 	  <div id="text">
-	    Let <span id=text_line_AB style='background-color: #dddddd'>line AB</span> be the given finite straight line.<br>It is required to construct an equilateral triangle on the straight <span id=text_line_AB style='background-color: #dddddd'>line AB</span>.<br>Describe the <span id=text_circle_BCD style='background-color: #dddddd'>circle BCD</span> with <span id=text_center_A style='background-color: #dddddd'>center A</span> and radius <span id=text_line_AB style='background-color: #dddddd'>line AB</span>.<br>Again describe the <span id=text_circle_ACE style='background-color: #dddddd'>circle ACE</span> with <span id=text_center_B style='background-color: #dddddd'>center B</span> and radius <span id=text_line_BA style='background-color: #dddddd'>line BA</span>.<br>Join the straight lines <span id=text_line_CA style='background-color: #dddddd'>line CA</span> and <span id=text_line_CB style='background-color: #dddddd'>line CB</span> from the <span id=text_point_C style='background-color: #dddddd'>point C</span> at which the circles cut one another to the points <span id=text_point_A style='background-color: #dddddd'>point A</span> and <span id=text_point_B style='background-color: #dddddd'>point B</span>.<br>Now, since the <span id=text_point_A style='background-color: #dddddd'>point A</span> is the center of the <span id=text_circle_CDB style='background-color: #dddddd'>circle CDB</span>, therefore <span id=text_line_AC style='background-color: #dddddd'>line AC</span> equals <span id=text_line_AB style='background-color: #dddddd'>line AB</span>.<br>Again, since the <span id=text_point_B style='background-color: #dddddd'>point B</span> is the center of the <span id=text_circle_CAE style='background-color: #dddddd'>circle CAE</span>, therefore <span id=text_line_BC style='background-color: #dddddd'>line BC</span> equals <span id=text_line_BA style='background-color: #dddddd'>line BA</span>.<br>But <span id=text_line_AC style='background-color: #dddddd'>line AC</span> was proved equal to <span id=text_line_AB style='background-color: #dddddd'>line AB</span>, therefore each of the straight lines <span id=text_line_AC style='background-color: #dddddd'>line AC</span> and <span id=text_line_BC style='background-color: #dddddd'>line BC</span> equals <span id=text_line_AB style='background-color: #dddddd'>line AB</span>.<br>And things which equal the same thing also equal one another, therefore <span id=text_line_AC style='background-color: #dddddd'>line AC</span> also equals <span id=text_line_BC style='background-color: #dddddd'>line BC</span>.<br>Therefore the three straight lines <span id=text_line_AC style='background-color: #dddddd'>line AC</span>, <span id=text_line_AB style='background-color: #dddddd'>line AB</span>, and <span id=text_line_BC style='background-color: #dddddd'>line BC</span> equal one another.<br>Therefore the <span id=text_triangle_ABC style='background-color: #dddddd'>triangle ABC</span> is equilateral, and it has been constructed on the given finite straight <span id=text_line_AB style='background-color: #dddddd'>line AB</span>.<br>
+	    Let <span id=text_line_AB style='background-color: #dddddd'>line AB</span> be the given finite straight line.<br>It is required to construct an equilateral triangle on the straight <span id=text_line_AB style='background-color: #dddddd'>line AB</span>. <br>Describe the <span id=text_circle_BCD style='background-color: #dddddd'>circle BCD</span> with <span id=text_center_A style='background-color: #dddddd'>center A</span> and radius <span id=text_line_AB style='background-color: #dddddd'>line AB</span>. <br>Again describe the <span id=text_circle_ACE style='background-color: #dddddd'>circle ACE</span> with <span id=text_center_B style='background-color: #dddddd'>center B</span> and radius <span id=text_line_BA style='background-color: #dddddd'>line BA</span>. <br>Join the straight lines <span id=text_line_CA style='background-color: #dddddd'>line CA</span> and <span id=text_line_CB style='background-color: #dddddd'>line CB</span> from the <span id=text_point_C style='background-color: #dddddd'>point C</span> at which the circles cut one another to the points <span id=text_point_A style='background-color: #dddddd'>point A</span> and <span id=text_point_B style='background-color: #dddddd'>point B</span>. <br>Now, since the <span id=text_point_A style='background-color: #dddddd'>point A</span> is the center of the <span id=text_circle_CDB style='background-color: #dddddd'>circle CDB</span>, therefore <span id=text_line_AC style='background-color: #dddddd'>line AC</span> equals <span id=text_line_AB style='background-color: #dddddd'>line AB</span>.<br>Again, since the <span id=text_point_B style='background-color: #dddddd'>point B</span> is the center of the <span id=text_circle_CAE style='background-color: #dddddd'>circle CAE</span>, therefore <span id=text_line_BC style='background-color: #dddddd'>line BC</span> equals <span id=text_line_BA style='background-color: #dddddd'>line BA</span>.<br>But <span id=text_line_AC style='background-color: #dddddd'>line AC</span> was proved equal to <span id=text_line_AB style='background-color: #dddddd'>line AB</span>, therefore each of the straight lines <span id=text_line_AC style='background-color: #dddddd'>line AC</span> and <span id=text_line_BC style='background-color: #dddddd'>line BC</span> equals <span id=text_line_AB style='background-color: #dddddd'>line AB</span>.<br>And things which equal the same thing also equal one another, therefore <span id=text_line_AC style='background-color: #dddddd'>line AC</span> also equals <span id=text_line_BC style='background-color: #dddddd'>line BC</span>.<br>Therefore the three straight lines <span id=text_line_AC style='background-color: #dddddd'>line AC</span>, <span id=text_line_AB style='background-color: #dddddd'>line AB</span>, and <span id=text_line_BC style='background-color: #dddddd'>line BC</span> equal one another.<br>Therefore the <span id=text_triangle_ABC style='background-color: #dddddd'>triangle ABC</span> is equilateral, and it has been constructed on the given finite straight <span id=text_line_AB style='background-color: #dddddd'>line AB</span>. <br>
 	  </div>
 	</body>
 </html>
-

--- a/frontend/texts/postulate-1.yc
+++ b/frontend/texts/postulate-1.yc
@@ -1,4 +1,4 @@
-`step` Let `line AB` be the given finite straight line.
+Let `line AB` be the given finite straight line.
 It is required to construct an equilateral triangle on the straight `line AB`. `step`
 Describe the `circle BCD` with `center A circle=BCD` and radius `line AB`. `step`
 Again describe the `circle ACE` with `center B circle=ACE` and radius `line BA`. `step`
@@ -8,7 +8,7 @@ Again, since the `point B` is the center of the `circle CAE`, therefore `line BC
 But `line AC` was proved equal to `line AB`, therefore each of the straight lines `line AC` and `line BC` equals `line AB`.
 And things which equal the same thing also equal one another, therefore `line AC` also equals `line BC`.
 Therefore the three straight lines `line AC`, `line AB`, and `line BC` equal one another.
-Therefore the `triangle ABC` is equilateral, and it has been constructed on the given finite straight `line AB`.
+Therefore the `triangle ABC` is equilateral, and it has been constructed on the given finite straight `line AB`. `step`
 
 `loc A -0.25 0`
 `loc B 0.25 0`


### PR DESCRIPTION
- Remove a `step` from being required on the first line
- Remove `step` from appearing in the HTML
- Add `step` at the end of the postulate