### PR TITLE
Remove position attribute is js

### DIFF
--- a/frontend/index.js
+++ b/frontend/index.js
@@ -331,7 +331,6 @@ function makeLabels(data) {
 	    let elem = document.createElement('div')
 	    elem.id = obj.id
 	    elem.innerHTML = obj.label
-	    elem.style.position = 'absolute'
 	    elem.className = 'label'
 	    elem.style.display = "none"
 	    let x = 0


### PR DESCRIPTION
So the merge reintroduced this line which broke the labels on the mobile view.

Can this get merged in now?